### PR TITLE
Added serializability functionality

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var events = require('events');
 var util = require('util');
+var circularJSON = require('circular-json');
 
 module.exports = LFU;
 
@@ -107,6 +108,7 @@ LFU.prototype.remove = function(key) {
 };
 
 LFU.prototype.removeFromParent = function(parent, key) {
+	Object.setPrototypeOf(parent.items, new Set());
 	parent.items.remove(key);
 	if (parent.items.length == 0) {
 		parent.prev.next = parent.next;
@@ -122,6 +124,14 @@ LFU.prototype.evict = function() {
 		throw new Error("Cannot find an element to evict - please report issue");
 	}
 };
+
+LFU.prototype.export = function() {
+	return circularJSON.stringify(this.cache);
+}
+
+LFU.prototype.import = function(cache) {
+	this.cache = circularJSON.parse(cache);
+}
 
 function freq() {
 	return {

--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
   },
   "devDependencies": {
     "mocha": "^2.1.0"
+  },
+  "dependencies": {
+    "circular-json": "^0.3.1"
   }
 }


### PR DESCRIPTION
Some users might need an import/export functionality for the current LFUCache data-structure for portability/transmission over get/post requests and storage. 

Added:

import(): To import and set an already existing LFUCache
export(): To export an already existing LFUCache as string

Additional dependencies: circular-json to parse and stringify Circular referenced JSON Objects. 